### PR TITLE
COMP: Fix configure error on linux platform

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,7 @@ include(${Slicer_USE_FILE})
 
 #-----------------------------------------------------------------------------
 # Extension modules
-add_subdirectory(MUSTSegmenter)
+add_subdirectory(MUSTsegmenter)
 ## NEXT_MODULE
 
 #-----------------------------------------------------------------------------


### PR DESCRIPTION
There was a case sensitive issue with adding the module subdirectory. See error below:
https://slicer.cdash.org/build/2891662/configure
```
CMake Error at CMakeLists.txt:26 (add_subdirectory):
  add_subdirectory given source "MUSTSegmenter" which is not an existing
  directory.
```