### PR TITLE
Fix wrong message about SlicerRadiomics not installed and use nondeprecated Markups API

### DIFF
--- a/MUSTsegmenter/MUSTsegmenter.py
+++ b/MUSTsegmenter/MUSTsegmenter.py
@@ -1217,7 +1217,6 @@ class MUSTsegmenterLogic(ScriptedLoadableModuleLogic):
     """
     Method that extracts the center and the radius from the given ROI
     """
-    roi.SetVolumeNodeID(petVolume.GetID())
     # Get RAS coordinates
     center = [0, 0, 0]
     radius = [0, 0, 0]

--- a/MUSTsegmenter/MUSTsegmenter.py
+++ b/MUSTsegmenter/MUSTsegmenter.py
@@ -24,7 +24,7 @@ class MUSTsegmenter(ScriptedLoadableModule):
     Please refer to https://github.com/kyliekeijzer/Slicer-PET-MUST-segmenter
     """
     self.parent.acknowledgementText = """
-    This segmentation extension was developed by Kylie Keijzer, 
+    This segmentation extension was developed by Kylie Keijzer,
     University Medical Center Groningen (UMCG), The Netherlands.
     """
 
@@ -317,6 +317,7 @@ class MUSTsegmenterLogic(ScriptedLoadableModuleLogic):
         self.Conv3d = Conv3d
         self.torchTensor = tensor
 
+    slicer.modules.slicerradiomics.widgetRepresentation()  # SlicerRadiomics installs additional python packages on widget instantiation
     try:
       from radiomics import featureextractor
       self.featureextractor = featureextractor


### PR DESCRIPTION
`BUG: Fix incorrect message about SlicerRadiomics not installed`
If SlicerRadiomics-is installed for the first time with PET-MUST-Segmenter, then upon restart and entering PET-MUST-Segmenter it will warn that SlicerRadiomics is not installed when actually it is installed. It is just importing featureextractor was not successfull because the user has not enter the SlicerRadiomics module yet which installs additional python packages.

`ENH: Use nondeprecated Markups API`
Switch to using non-deprecated markups API methods.

vtkMRMLAnnotationROINode objects are legacy and to be removed soon in Slicer. vtkMRMLMarkupsROINode should be used instead.

With this change, the following screenshots will be outdated:
- https://github.com/kyliekeijzer/Slicer-PET-MUST-segmenter/blob/8457d67fa15de898c7baf70015614e6f6d9fa95e/screenshots/11.png, Markups ROI objects are created from the Markups module
- https://github.com/kyliekeijzer/Slicer-PET-MUST-segmenter/blob/8457d67fa15de898c7baf70015614e6f6d9fa95e/screenshots/12.png, Markups ROI objects look slightly different from Annotation ROI objects. That have more display options such as changing the display color of the bounding box.